### PR TITLE
URL Cleanup

### DIFF
--- a/doc/reference/lib/fop-0.95/lib/README.txt
+++ b/doc/reference/lib/fop-0.95/lib/README.txt
@@ -5,7 +5,7 @@ Information on Apache FOP dependencies
 $Id$
 
 The Apache Licenses can also be found here:
-http://www.apache.org/licenses/
+https://www.apache.org/licenses/
 
 
 Normal Dependencies

--- a/doc/reference/lib/fop-0.95/lib/avalon-framework.LICENSE.txt
+++ b/doc/reference/lib/fop-0.95/lib/avalon-framework.LICENSE.txt
@@ -1,7 +1,7 @@
 
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 

--- a/doc/reference/lib/fop-0.95/lib/batik.LICENSE.txt
+++ b/doc/reference/lib/fop-0.95/lib/batik.LICENSE.txt
@@ -1,6 +1,6 @@
                                   Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/doc/reference/lib/fop-0.95/lib/commons-io.LICENSE.txt
+++ b/doc/reference/lib/fop-0.95/lib/commons-io.LICENSE.txt
@@ -1,7 +1,7 @@
 
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -193,7 +193,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/doc/reference/lib/fop-0.95/lib/commons-logging.LICENSE.txt
+++ b/doc/reference/lib/fop-0.95/lib/commons-logging.LICENSE.txt
@@ -1,7 +1,7 @@
 
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -193,7 +193,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/doc/reference/lib/fop-0.95/lib/serializer.LICENSE.txt
+++ b/doc/reference/lib/fop-0.95/lib/serializer.LICENSE.txt
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/doc/reference/lib/fop-0.95/lib/xalan.LICENSE.txt
+++ b/doc/reference/lib/fop-0.95/lib/xalan.LICENSE.txt
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/doc/reference/lib/fop-0.95/lib/xercesImpl.LICENSE.txt
+++ b/doc/reference/lib/fop-0.95/lib/xercesImpl.LICENSE.txt
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/doc/reference/lib/fop-0.95/lib/xml-apis-ext.LICENSE.txt
+++ b/doc/reference/lib/fop-0.95/lib/xml-apis-ext.LICENSE.txt
@@ -1,7 +1,7 @@
 
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -193,7 +193,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/doc/reference/lib/fop-0.95/lib/xml-apis.LICENSE.txt
+++ b/doc/reference/lib/fop-0.95/lib/xml-apis.LICENSE.txt
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/doc/reference/lib/fop-0.95/lib/xmlgraphics-commons.LICENSE.txt
+++ b/doc/reference/lib/fop-0.95/lib/xmlgraphics-commons.LICENSE.txt
@@ -1,7 +1,7 @@
 
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -193,7 +193,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/license.txt
+++ b/license.txt
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring.Social.Dropbox/Social/Dropbox/Api/AccessLevel.cs
+++ b/src/Spring.Social.Dropbox/Social/Dropbox/Api/AccessLevel.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring.Social.Dropbox/Social/Dropbox/Api/DeltaEntry.cs
+++ b/src/Spring.Social.Dropbox/Social/Dropbox/Api/DeltaEntry.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring.Social.Dropbox/Social/Dropbox/Api/DeltaPage.cs
+++ b/src/Spring.Social.Dropbox/Social/Dropbox/Api/DeltaPage.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring.Social.Dropbox/Social/Dropbox/Api/DropboxApiError.cs
+++ b/src/Spring.Social.Dropbox/Social/Dropbox/Api/DropboxApiError.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring.Social.Dropbox/Social/Dropbox/Api/DropboxApiException.cs
+++ b/src/Spring.Social.Dropbox/Social/Dropbox/Api/DropboxApiException.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring.Social.Dropbox/Social/Dropbox/Api/DropboxFile.cs
+++ b/src/Spring.Social.Dropbox/Social/Dropbox/Api/DropboxFile.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring.Social.Dropbox/Social/Dropbox/Api/DropboxLink.cs
+++ b/src/Spring.Social.Dropbox/Social/Dropbox/Api/DropboxLink.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring.Social.Dropbox/Social/Dropbox/Api/DropboxProfile.cs
+++ b/src/Spring.Social.Dropbox/Social/Dropbox/Api/DropboxProfile.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring.Social.Dropbox/Social/Dropbox/Api/Entry.cs
+++ b/src/Spring.Social.Dropbox/Social/Dropbox/Api/Entry.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring.Social.Dropbox/Social/Dropbox/Api/FileRef.cs
+++ b/src/Spring.Social.Dropbox/Social/Dropbox/Api/FileRef.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring.Social.Dropbox/Social/Dropbox/Api/IDropbox.cs
+++ b/src/Spring.Social.Dropbox/Social/Dropbox/Api/IDropbox.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring.Social.Dropbox/Social/Dropbox/Api/Impl/DropboxErrorHandler.cs
+++ b/src/Spring.Social.Dropbox/Social/Dropbox/Api/Impl/DropboxErrorHandler.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring.Social.Dropbox/Social/Dropbox/Api/Impl/DropboxFileHttpMessageConverter.cs
+++ b/src/Spring.Social.Dropbox/Social/Dropbox/Api/Impl/DropboxFileHttpMessageConverter.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring.Social.Dropbox/Social/Dropbox/Api/Impl/DropboxTemplate.cs
+++ b/src/Spring.Social.Dropbox/Social/Dropbox/Api/Impl/DropboxTemplate.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring.Social.Dropbox/Social/Dropbox/Api/Impl/Json/DeltaPageDeserializer.cs
+++ b/src/Spring.Social.Dropbox/Social/Dropbox/Api/Impl/Json/DeltaPageDeserializer.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring.Social.Dropbox/Social/Dropbox/Api/Impl/Json/DropboxLinkDeserializer.cs
+++ b/src/Spring.Social.Dropbox/Social/Dropbox/Api/Impl/Json/DropboxLinkDeserializer.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring.Social.Dropbox/Social/Dropbox/Api/Impl/Json/DropboxProfileDeserializer.cs
+++ b/src/Spring.Social.Dropbox/Social/Dropbox/Api/Impl/Json/DropboxProfileDeserializer.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring.Social.Dropbox/Social/Dropbox/Api/Impl/Json/EntryDeserializer.cs
+++ b/src/Spring.Social.Dropbox/Social/Dropbox/Api/Impl/Json/EntryDeserializer.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring.Social.Dropbox/Social/Dropbox/Api/Impl/Json/EntryListDeserializer.cs
+++ b/src/Spring.Social.Dropbox/Social/Dropbox/Api/Impl/Json/EntryListDeserializer.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring.Social.Dropbox/Social/Dropbox/Api/Impl/Json/FileRefDeserializer.cs
+++ b/src/Spring.Social.Dropbox/Social/Dropbox/Api/Impl/Json/FileRefDeserializer.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring.Social.Dropbox/Social/Dropbox/Api/Impl/Json/JsonUtils.cs
+++ b/src/Spring.Social.Dropbox/Social/Dropbox/Api/Impl/Json/JsonUtils.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring.Social.Dropbox/Social/Dropbox/Api/MetadataParameters.cs
+++ b/src/Spring.Social.Dropbox/Social/Dropbox/Api/MetadataParameters.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring.Social.Dropbox/Social/Dropbox/Api/ThumbnailFormat.cs
+++ b/src/Spring.Social.Dropbox/Social/Dropbox/Api/ThumbnailFormat.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring.Social.Dropbox/Social/Dropbox/Api/ThumbnailSize.cs
+++ b/src/Spring.Social.Dropbox/Social/Dropbox/Api/ThumbnailSize.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring.Social.Dropbox/Social/Dropbox/Connect/DropboxServiceProvider.cs
+++ b/src/Spring.Social.Dropbox/Social/Dropbox/Connect/DropboxServiceProvider.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring.Social.Dropbox.Tests/Social/Dropbox/Api/DropboxApiExceptionTests.cs
+++ b/test/Spring.Social.Dropbox.Tests/Social/Dropbox/Api/DropboxApiExceptionTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring.Social.Dropbox.Tests/Social/Dropbox/Api/Impl/DropboxTemplateTests.cs
+++ b/test/Spring.Social.Dropbox.Tests/Social/Dropbox/Api/Impl/DropboxTemplateTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring.Social.Dropbox.Tests/Social/Dropbox/Api/Impl/ErrorHandlerTests.cs
+++ b/test/Spring.Social.Dropbox.Tests/Social/Dropbox/Api/Impl/ErrorHandlerTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring.Social.Dropbox.Tests/Util/SerializationTestUtils.cs
+++ b/test/Spring.Social.Dropbox.Tests/Util/SerializationTestUtils.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/ with 12 occurrences migrated to:  
  https://www.apache.org/licenses/ ([https](https://www.apache.org/licenses/) result 200).
* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 39 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).